### PR TITLE
Implement ethereum_types uints, add benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ arrayvec = { version = "0.7", default-features = false }
 auto_impl = "0.5"
 bytes = { version = "1", default-features = false }
 ethnum = { version = "1", default-features = false, optional = true }
-ethereum-types = { version = "0.13", default-features = false, optional = true }
+ethereum-types = { version = "0.13", default-features = false, optional = true, features = ["rlp"]}
 fastrlp-derive = { version = "0.1", path = "fastrlp-derive", optional = true }
 
 [dev-dependencies]
@@ -21,6 +21,7 @@ fastrlp-test = { path = ".", package = "fastrlp", features = [
     "ethnum",
     "ethereum-types",
 ] }
+rlp = { version = "0.5.0", default-features = false }
 criterion = "0.3"
 hex-literal = "0.3"
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,9 +10,50 @@
 
 use bytes::BytesMut;
 use criterion::{criterion_group, criterion_main, Criterion};
-use ethnum::*;
+use ethnum::U256;
 use fastrlp::*;
 use hex_literal::hex;
+
+// This wraps the ethnum U256 so we can implement Encodable and Decodable from the rlp crate for
+// comparison during benchmarks
+struct WrappedU256(U256);
+
+// This From implementation assumes the bytes being passed represent a u256 in big endian.
+impl From<&[u8]> for WrappedU256 {
+    fn from(bytes: &[u8]) -> Self {
+        if bytes.len() > 32 {
+            panic!("Can't convert a byte slice greater than 32 bytes to a U256");
+        }
+        WrappedU256 {
+            0: {
+                let mut u256_backing = [0u8; 32];
+                u256_backing[32 - bytes.len()..].copy_from_slice(bytes);
+                U256::from_be_bytes(u256_backing)
+            },
+        }
+    }
+}
+
+impl rlp::Encodable for WrappedU256 {
+    fn rlp_append(&self, s: &mut rlp::RlpStream) {
+        let buffer = self.0.to_be_bytes();
+        s.encoder().encode_value(&buffer);
+    }
+}
+
+impl rlp::Decodable for WrappedU256 {
+    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        rlp.decoder().decode_value(|bytes| {
+            if !bytes.is_empty() && bytes[0] == 0 {
+                Err(rlp::DecoderError::RlpInvalidIndirection)
+            } else if bytes.len() <= 32 {
+                Ok(WrappedU256::from(bytes))
+            } else {
+                Err(rlp::DecoderError::RlpIsTooBig)
+            }
+        })
+    }
+}
 
 fn bench_encode(c: &mut Criterion) {
     c.bench_function("encode_u64", |b| {
@@ -30,6 +71,16 @@ fn bench_encode(c: &mut Criterion) {
             uint.encode(&mut out);
         })
     });
+    #[cfg(feature = "ethereum-types")]
+    c.bench_function("encode_eth_types_u256", |b| {
+        b.iter(|| {
+            let mut out = BytesMut::new();
+            let uint = ethereum_types::U256::from_big_endian(
+                &hex!("8090a0b0c0d0e0f00910203040506077000000000000000100000000000012f0")[..],
+            );
+            uint.encode(&mut out);
+        })
+    });
     c.bench_function("encode_1000_u64", |b| {
         b.iter(|| {
             let mut out = BytesMut::new();
@@ -37,6 +88,31 @@ fn bench_encode(c: &mut Criterion) {
                 (0..1000u64).into_iter().collect::<Vec<_>>().as_slice(),
                 &mut out,
             );
+        })
+    });
+}
+
+fn bench_old_encode(c: &mut Criterion) {
+    c.bench_function("old_encode_u64", |b| {
+        b.iter(|| {
+            let _out = rlp::Encodable::rlp_bytes(&0x1023_4567_89ab_cdefu64);
+        })
+    });
+    c.bench_function("old_encode_u256", |b| {
+        b.iter(|| {
+            let uint = WrappedU256(U256::from_be_bytes(hex!(
+                "8090a0b0c0d0e0f00910203040506077000000000000000100000000000012f0"
+            )));
+            let _out = rlp::Encodable::rlp_bytes(&uint);
+        })
+    });
+    #[cfg(feature = "ethereum-types")]
+    c.bench_function("encode_old_eth_types_u256", |b| {
+        b.iter(|| {
+            let uint = ethereum_types::U256::from_big_endian(
+                &hex!("8090a0b0c0d0e0f00910203040506077000000000000000100000000000012f0")[..],
+            );
+            let _out = rlp::Encodable::rlp_bytes(&uint);
         })
     });
 }
@@ -68,5 +144,50 @@ fn bench_decode(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_encode, bench_decode);
+fn bench_old_decode(c: &mut Criterion) {
+    c.bench_function("decode_old_u64_trusted", |b| {
+        b.iter(|| {
+            let data = [0x88, 0x10, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
+            let _: u64 = rlp::decode(&data[..]).unwrap();
+        })
+    });
+    c.bench_function("decode_old_u64_untrusted", |b| {
+        b.iter(|| {
+            let data = [0x88, 0x10, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
+            let data_rlp = rlp::Rlp::new(&data[..]);
+            let _: u64 = <u64 as rlp::Decodable>::decode(&data_rlp).unwrap();
+        })
+    });
+    #[cfg(feature = "ethereum-types")]
+    c.bench_function("decode_old_eth_u256_trusted", |b| {
+        b.iter(|| {
+            let data = vec![
+                0xa0, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0x09, 0x10, 0x20, 0x30, 0x40,
+                0x50, 0x60, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x12, 0xf0,
+            ];
+            let _: ethereum_types::U256 = rlp::decode(&data[..]).unwrap();
+        })
+    });
+    #[cfg(feature = "ethereum-types")]
+    c.bench_function("decode_old_eth_u256_untrusted", |b| {
+        b.iter(|| {
+            let data = vec![
+                0xa0, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0x09, 0x10, 0x20, 0x30, 0x40,
+                0x50, 0x60, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x12, 0xf0,
+            ];
+            let uint_rlp = rlp::Rlp::new(&data[..]);
+            let _ = <ethereum_types::U256 as rlp::Decodable>::decode(&uint_rlp).unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_old_encode,
+    bench_old_decode,
+    bench_encode,
+    bench_decode
+);
 criterion_main!(benches);


### PR DESCRIPTION
Added benchmarks to compare the `rlp` crate's encoding and decoding with the `fastrlp` encoding and decoding. Also implemented `fastrlp` encoding for `U512`, `U256`, `U128`, and `U64` from `ethereum_types`.